### PR TITLE
Add additional meta data to responses.

### DIFF
--- a/lib/apib2json.js
+++ b/lib/apib2json.js
@@ -102,6 +102,15 @@ class Apib2Json {
                                                 schema: rContent.content,
                                             };
 
+                                            if ('meta' in resource && 'title' in resource.meta) {
+                                                item.meta.group = resource.meta.title;
+                                            }
+
+                                            if ('attributes' in httpTransaction &&
+                                                'statusCode' in httpTransaction.attributes) {
+                                                item.meta.statusCode = httpTransaction.attributes.statusCode;
+                                            }
+
                                             if ('meta' in httpTransaction && 'title' in httpTransaction.meta) {
                                                 item.meta.title = httpTransaction.meta.title;
                                             }

--- a/test/fixtures/advanced_attributes_api.expected.json
+++ b/test/fixtures/advanced_attributes_api.expected.json
@@ -3,7 +3,9 @@
     {
       "meta": {
         "type": "response",
-        "title": null
+        "title": null,
+        "group": "Coupon",
+        "statusCode": "200"
       },
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -35,7 +37,9 @@
     {
       "meta": {
         "type": "response",
-        "title": null
+        "title": null,
+        "group": "Coupons",
+        "statusCode": "200"
       },
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -47,7 +51,9 @@
     {
       "meta": {
         "type": "response",
-        "title": null
+        "title": null,
+        "group": "Coupons",
+        "statusCode": "200"
       },
       "schema": {
         "$schema": "http://json-schema.org/draft-04/schema#",

--- a/test/fixtures/custom_api.expected.json
+++ b/test/fixtures/custom_api.expected.json
@@ -3,7 +3,8 @@
         {
             "meta": {
                 "type": "request",
-                "title": "Success"
+                "title": "Success",
+                "group": "Account"
             },
             "schema": {
                 "$schema": "http://json-schema.org/draft-04/schema#",
@@ -25,7 +26,9 @@
         {
             "meta": {
                 "type": "response",
-                "title": null
+                "title": null,
+                "group": "Account",
+                "statusCode": "200"
             },
             "schema": {
                 "$schema": "http://json-schema.org/draft-04/schema#",
@@ -40,7 +43,8 @@
         {
             "meta": {
                 "type": "request",
-                "title": "Bad Credentials"
+                "title": "Bad Credentials",
+                "group": "Account"
             },
             "schema": {
                 "$schema": "http://json-schema.org/draft-04/schema#",
@@ -62,7 +66,9 @@
         {
             "meta": {
                 "type": "response",
-                "title": null
+                "title": null,
+                "group": "Account",
+                "statusCode": "401"
             },
             "schema": {
                 "$schema": "http://json-schema.org/draft-04/schema#",
@@ -90,7 +96,9 @@
         {
             "meta": {
                 "type": "response",
-                "title": null
+                "title": null,
+                "group": "Account",
+                "statusCode": "200"
             },
             "schema": {
                 "$schema": "http://json-schema.org/draft-04/schema#",
@@ -114,7 +122,9 @@
         {
             "meta": {
                 "type": "response",
-                "title": null
+                "title": null,
+                "group": "Article",
+                "statusCode": "200"
             },
             "schema": {
                 "$schema": "http://json-schema.org/draft-04/schema#",


### PR DESCRIPTION
This MR will add two new attributes to response meta data
- `group`
- `statusCode`

This information is useful to parse this document and figure out the purpose of the responses. Here is an example of the output.

```
      "meta": {
        "type": "response",
        "title": null,
        "group": "Customer",
        "statusCode": "422"
      }
```

Just by looking at the metadata with another program I can tell the schema belongs to a response from Customer and is the response schema for status 422. 

My use case is that the same endpoint can respond with different statuses and also have a different response format.